### PR TITLE
Add Nado referral inline link

### DIFF
--- a/en/05-volume-farmer.md
+++ b/en/05-volume-farmer.md
@@ -12,7 +12,7 @@ Running this every N minutes accumulates points by season's end.
 
 ### Where it works
 
-- **Perp DEXs during airdrop seasons** ([Hyperliquid](https://miracletrade.com/?ref=coinmage), [Lighter](https://app.lighter.xyz/?referral=GMYPZWQK69X4), [EdgeX](https://pro.edgex.exchange/referral/570254647), Nado, [GRVT](https://grvt.io/exchange/sign-up?ref=1O9U2GG), etc.)
+- **Perp DEXs during airdrop seasons** ([Hyperliquid](https://miracletrade.com/?ref=coinmage), [Lighter](https://app.lighter.xyz/?referral=GMYPZWQK69X4), [EdgeX](https://pro.edgex.exchange/referral/570254647), [Nado](https://app.nado.xyz?join=NX9LLaL), [GRVT](https://grvt.io/exchange/sign-up?ref=1O9U2GG), etc.)
 - **Volume-based exchange campaigns** (Bybit, OKX run these often)
 - **Maker-rebate exchanges** — if maker fees are negative, the volume itself is profit
 

--- a/ko/05-volume-farmer.md
+++ b/ko/05-volume-farmer.md
@@ -12,7 +12,7 @@
 
 ### 어디서 유용한가
 
-- **에어드랍 시즌의 Perp DEX** ([Hyperliquid](https://miracletrade.com/?ref=coinmage), [Lighter](https://app.lighter.xyz/?referral=GMYPZWQK69X4), [EdgeX](https://pro.edgex.exchange/referral/570254647), Nado, [GRVT](https://grvt.io/exchange/sign-up?ref=1O9U2GG) 등)
+- **에어드랍 시즌의 Perp DEX** ([Hyperliquid](https://miracletrade.com/?ref=coinmage), [Lighter](https://app.lighter.xyz/?referral=GMYPZWQK69X4), [EdgeX](https://pro.edgex.exchange/referral/570254647), [Nado](https://app.nado.xyz?join=NX9LLaL), [GRVT](https://grvt.io/exchange/sign-up?ref=1O9U2GG) 등)
 - **거래량 기반 거래소 캠페인** (Bybit, OKX 등 종종 진행)
 - **메이커 리베이트 거래소** — 메이커 수수료가 음수면 볼륨 자체가 수익
 

--- a/perp-dex-wrappers/README.md
+++ b/perp-dex-wrappers/README.md
@@ -35,7 +35,7 @@
 | Bulk | `bulk/` | 테스트넷 (격리 venv, Ed25519) |
 | [Extended](https://app.extended.exchange/join/COINMAGE) | `extended/` | StarkNet DEX |
 | Hotstuff | `hotstuff/` | HL 기반 |
-| Nado | `nado/` | HL 기반 |
+| [Nado](https://app.nado.xyz?join=NX9LLaL) | `nado/` | HL 기반 |
 | [Miracle](https://miracletrade.com/?ref=coinmage) / DreamCash / [Bullpen](https://miracletrade.com/?ref=coinmage) | (HL aliases) | builder code only, base wrapper 공유 |
 
 ## 파일 구조


### PR DESCRIPTION
## Summary

- Nado referral (`https://app.nado.xyz?join=NX9LLaL`) linked at every plain "Nado" mention in markdown
- 3 inline links across 3 files (perp-dex-wrappers/README.md, en/05, ko/05)

🤖 Generated with [Claude Code](https://claude.com/claude-code)